### PR TITLE
Add pre commit tools

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,19 +25,21 @@ repos:
   - id: python-check-blanket-noqa
   - id: python-use-type-annotations
   - id: rst-backticks
-#- repo: https://github.com/pre-commit/mirrors-isort
+# - repo: https://github.com/pre-commit/mirrors-isort
 - repo: https://github.com/timothycrosley/isort
   rev: 4.3.21-2
   hooks:
   - id: isort
     additional_dependencies: [toml]
-- repo: https://github.com/ambv/black
-  rev: 19.3b0
+- repo: https://github.com/psf/black
+  rev: 19.10b0
   hooks:
   - id: black
     language: system
-- repo: https://github.com/pycqa/pylint
-  rev: pylint-2.4.4
+# - repo: https://github.com/pycqa/pylint
+#   rev: pylint-2.4.4
+- repo: https://github.com/pre-commit/mirrors-pylint
+  rev: v2.4.4
   hooks:
   - id: pylint
     language: system
@@ -45,6 +47,12 @@ repos:
   rev: 3.7.8
   hooks:
   - id: flake8
+    language: system
+# - repo: https://github.com/python/mypy
+- repo: https://github.com/pre-commit/mirrors-mypy
+  rev: v0.750
+  hooks:
+  - id: mypy
     language: system
 default_language_version:
   python: python3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,12 +25,18 @@ repos:
   - id: python-check-blanket-noqa
   - id: python-use-type-annotations
   - id: rst-backticks
+#- repo: https://github.com/pre-commit/mirrors-isort
+- repo: https://github.com/timothycrosley/isort
+  rev: 4.3.21-2
+  hooks:
+  - id: isort
+    additional_dependencies: [toml]
 - repo: https://github.com/ambv/black
   rev: 19.3b0
   hooks:
   - id: black
-    args: [-q, --line-length=79, --target-version=py36]
-- repo: https://github.com/PyCQA/pylint
+    language: system
+- repo: https://github.com/pycqa/pylint
   rev: pylint-2.4.4
   hooks:
   - id: pylint

--- a/ci/templates/.travis.yml
+++ b/ci/templates/.travis.yml
@@ -7,10 +7,10 @@ env:
     - SEGFAULT_SIGNALS=all
 matrix:
   include:
-    - python: '3.6'
+    - python: '3.7'
       env:
         - TOXENV=check
-    - python: '3.6'
+    - python: '3.7'
       env:
         - TOXENV=docs
 {%- for env in tox_environments %}{{ '' }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,4 +5,15 @@ requires = [
     "wheel",
 ]
 
-[tools.setuptools_scm]
+[tool.black]
+line-length = 79
+target-version = ["py37","py38"]
+
+[tool.isort]
+include_trailing_comma = true
+line_length = 79
+multi_line_output = 3
+known_first_party = ["dsdk"]
+default_section = "THIRDPARTY"
+
+[tool.setuptools_scm]

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,12 @@ coverage_flags =
     nocover: false
 
 
-[tool:pytest]
+[mypy]
+follow_imports = normal
+ignore_missing_imports = True
+
+
+[pytest]
 # If a pytest section is found in one of the possible config files
 # (pytest.ini, tox.ini or setup.cfg), then pytest will not look for any others,
 # so if you add a pytest config section elsewhere,

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,12 +1,6 @@
 [bdist_wheel]
 universal = 1
 
-[flake8]
-max-complexity = 10
-max-line-length = 79
-exclude = ci,docs
-ignore = C812,D401
-
 [options]
 # tests_require is a list of dependencies that are *absolutely required*
 # to run the tests. tests_require is used when running tests from your
@@ -31,6 +25,13 @@ tests_require = pytest
 [aliases]
 # Alias `setup.py test` to `setup.py pytest`
 test = pytest
+
+
+[flake8]
+max-complexity = 10
+max-line-length = 79
+exclude = ci,docs
+ignore = C812,D202,D401
 
 
 [matrix]
@@ -70,10 +71,3 @@ addopts =
     --tb=short
 testpaths =
     tests
-
-[tool:isort]
-line_length = 79
-known_first_party = dsdk
-default_section = THIRDPARTY
-forced_separate = test_dsdk
-not_skip = __init__.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ follow_imports = normal
 ignore_missing_imports = True
 
 
-[pytest]
+[tool:pytest]
 # If a pytest section is found in one of the possible config files
 # (pytest.ini, tox.ini or setup.cfg), then pytest will not look for any others,
 # so if you add a pytest config section elsewhere,

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ LINT_REQUIRES = (
     "flake8-mutable",
     "flake8-sorted-keys",
     "isort",
+    "mypy",
     "pep8-naming",
     "pre-commit",
     "pylint",

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ KEYWORDS = (
 
 SETUP_REQUIRES = ("pytest-runner", "setuptools_scm>=3.3.3")
 
-TEST_REQUIRES = ("coverage", "pytest", "pytest-cov")
+TEST_REQUIRES = ("coverage", "pytest", "pytest-cov", "tox")
 
 
 def read(*names, **kwargs):

--- a/src/dsdk/utils.py
+++ b/src/dsdk/utils.py
@@ -94,10 +94,10 @@ def get_res_with_values(query, values, conn) -> list:
     return data_d
 
 
-def chunks(l, n):
+def chunks(lst, n):
     """Yield successive n-sized chunks from l."""
-    for i in range(0, len(l), n):
-        yield l[i : i + n]  # noqa: E203
+    for i in range(0, len(lst), n):
+        yield lst[i : i + n]  # noqa: E203
 
 
 def chunk_res_with_values(

--- a/tox.ini
+++ b/tox.ini
@@ -31,8 +31,12 @@ passenv =
     *
 usedevelop = false
 deps =
+    black
     coverage
+    flake8
+    mypy
     pre-commit
+    pylint
     pytest
     pytest-cov
     pytest-travis-fold

--- a/tox.ini
+++ b/tox.ini
@@ -32,27 +32,23 @@ passenv =
 usedevelop = false
 deps =
     coverage
+    pre-commit
     pytest
     pytest-cov
     pytest-travis-fold
+    setuptools-scm
 commands =
+    pre-commit run --all-files
     {posargs:pytest}
 
 [testenv:check]
 deps =
-    coverage
     docutils
-    flake8
-    pylint
     readme-renderer
     pygments
-    setuptools-scm
-    black
 skip_install = true
 commands =
     python setup.py check --strict --metadata --restructuredtext
-    black --line-length=79 --target-version=py37 src tests setup.py
-    flake8 src
 
 [testenv:docs]
 usedevelop = true

--- a/tox.ini
+++ b/tox.ini
@@ -30,37 +30,23 @@ setenv =
 passenv =
     *
 usedevelop = false
-deps =
-    black
-    coverage
-    flake8
-    mypy
-    pre-commit
-    pylint
-    pytest
-    pytest-cov
-    pytest-travis-fold
-    setuptools-scm
 commands =
+    python -m pip install .[lint]
     pre-commit run --all-files
+    python -m pip install .[test]
     {posargs:pytest}
 
 [testenv:check]
-deps =
-    docutils
-    readme-renderer
-    pygments
-skip_install = true
 commands =
+    python -m pip install .[check]
     python setup.py check --strict --metadata --restructuredtext
 
-[testenv:docs]
+[testenv:doc]
 usedevelop = true
 install_command =
     python -m pip install --no-use-pep517 {opts} {packages}
-deps =
-    -r{toxinidir}/docs/requirements.txt
 commands =
+    python -m pip install .[doc]
     sphinx-build {posargs:-E} -b html docs dist/docs
     sphinx-build -b linkcheck docs dist/docs
 


### PR DESCRIPTION
Aid debugging by removing differences between the local and remote execution of `tox`, `pre-commit` and `pytest`:

Remove duplication of dependency lists from `tox.ini`, use the extras in `setup.py`
Remove most options and duplication from `tox.ini` and `.pre-commit-config.yaml` by using configuration in `setup.cfg`, `.pylintrc`, and `pyproject.toml`. Prefer `pyproject.toml`.

Add `isort` back into the project with configuration compatible with `black`.
Add `mypy` into the project to type-checking the type annotations.

Other issues have been created as out of scope for 1.0. for flaws discovered during work.

Documentation generation has been left (broken) as is.