### PR TITLE
Add mongo contextmanager

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,86 @@
+version: "3.7"
+
+configs:
+  freetds:
+    file: ./mssql/etc/freetds.conf
+  localtime:
+    file: ./etc/localtime
+  timezone:
+    file: ./etc/time
+
+volumes:
+  mssql-data:
+  mongo-data:
+  postgres-data:
+
+  mongo:
+    image: mongo:4.0.13-xenial
+    configs:
+    - source: localtime
+      target: /etc/localtime
+    - source: timezone
+      target: /etc/timezone
+    expose:
+    - "27017"
+    ports:
+    - "27017:27017"
+    restart: always
+    stop_signal: SIGINT
+    volumes:
+    - mongo-data:/data/db  # durable data
+    command: [--noauth, --smallfiles, --quiet]
+
+
+# mssql for test
+# MSSQL_COLLATION: LATIN1_GENERAL_100_CI_AS_SC
+
+  mssql:
+    image: mcr.microsoft.com/mssql/server:2019-GA-ubuntu-16.0.4
+    configs:
+    - source: localtime
+      target: /etc/localtime
+    - source: timezone
+      target: /etc/timezone
+    environment:
+      ACCEPT_EULA: Y
+      MSSQL_PID: Developer
+      MSSQL_COLLATION: LATIN1_GENERAL_100_CI_AS_SC_UTF8
+      MSSQL_SA_PASSWORD: YourStrong!Passw0rd
+    expose:
+    - "1433"
+    ports:
+    - "1433:1433"
+    stop_signal: SIGINT
+    secrets:
+    - secrets
+    volumes:
+    - mssql-data:/var/opt/mssql/data  # durable
+
+  postgres:
+    image: alpine-3.10-postgres-mongo-tds
+    build:
+      context: ./
+      dockerfile: ./postgres.dockerfile
+      args:
+        MONGO_FDW: 1
+        TDS_FDW: 1
+    configs:
+    - source: localtime
+      target: /etc/localtime
+    - source: timezone
+      target: /etc/timezone
+    - source: freetds
+      target: /etc/freetds.conf
+    links:
+    - mongo
+    - mssql
+    expose:
+    - "5432"
+    ports:
+    - "5432:5432"
+    restart: always
+    stop_signal: SIGINT
+    secrets:
+    - secrets
+    volumes:
+    - postgres-data:/usr/local/pgsql/data  # durable

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ test = pytest
 max-complexity = 10
 max-line-length = 79
 exclude = ci,docs
-ignore = C812,D202,D401
+ignore = C812,C816,D202,D401
 
 
 [matrix]

--- a/src/dsdk/utils.py
+++ b/src/dsdk/utils.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import pickle
 from collections import OrderedDict
 from datetime import datetime
+from warnings import warn
 
 from configargparse import ArgParser
 from pandas import DataFrame
@@ -55,6 +56,7 @@ def get_mongo_connection(uri: str) -> MongoClient:
     uri (str): e.g.
         mongodb://user:pass@host1,host2,host3/database?replicaSet=replica&authSource=admin
     """
+    warn("Use dsdk.mongo:open_database.", DeprecationWarning)
     return MongoClient(uri)
 
 


### PR DESCRIPTION
Add mongo context manager.

Add docker-compose for test databases using named volumes instead of synchronized data directories.

Use `docker-compose run --service-ports mongo` to check the mongo context manager and the deprecated get_mongo_connection code.

```
from dsdk.mongo import open_database
...
with open_database(mongo_uri) as db:
    print('It works!)
```

Closes #30 