### PR TITLE
Extract logger config

### DIFF
--- a/src/dsdk/model.py
+++ b/src/dsdk/model.py
@@ -12,7 +12,7 @@ from configargparse import ArgParser as ArgumentParser
 from .service import Model, Service
 from .utils import get_logger, load_pickle_file
 
-logger = get_logger(__file__, INFO)
+logger = get_logger(__name__, INFO)
 
 
 if TYPE_CHECKING:

--- a/src/dsdk/model.py
+++ b/src/dsdk/model.py
@@ -4,32 +4,15 @@
 from __future__ import annotations
 
 from abc import ABC
-from logging import (
-    INFO,
-    Logger,
-    LoggerAdapter,
-    NullHandler,
-    basicConfig,
-    getLogger,
-)
+from logging import INFO
 from typing import TYPE_CHECKING, Optional, cast
 
 from configargparse import ArgParser as ArgumentParser
 
 from .service import Model, Service
-from .utils import load_pickle_file
+from .utils import get_logger, load_pickle_file
 
-# TODO Add import calling function from parent application
-EXTRA = {"callingfunc": ""}
-logger = getLogger(__name__)
-FORMAT = '%(asctime)-15s - %(name)s - %(levelname)s - {"callingfunc": \
-    "%(callingfunc)s", "module": "%(module)s", "function": "%(funcName)s", \
-        %(message)s}'
-basicConfig(format=FORMAT)
-logger.setLevel(INFO)
-# Add extra kwargs to message format
-logger.addHandler(NullHandler())
-logger = cast(Logger, LoggerAdapter(logger, EXTRA))
+logger = get_logger(__file__, INFO)
 
 
 if TYPE_CHECKING:

--- a/src/dsdk/mongo.py
+++ b/src/dsdk/mongo.py
@@ -5,14 +5,7 @@ from __future__ import annotations
 
 from abc import ABC
 from contextlib import contextmanager
-from logging import (
-    INFO,
-    Logger,
-    LoggerAdapter,
-    NullHandler,
-    basicConfig,
-    getLogger,
-)
+from logging import INFO
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -26,7 +19,7 @@ from typing import (
 from configargparse import ArgParser as ArgumentParser
 
 from .service import Batch, Model, Service
-from .utils import retry
+from .utils import get_logger, retry
 
 try:
     # Since not everyone will use mongo
@@ -41,17 +34,7 @@ except ImportError:
     Database = None
     AutoReconnect = None
 
-# TODO Add import calling function from parent application
-EXTRA = {"callingfunc": ""}
-logger = getLogger(__name__)
-FORMAT = '%(asctime)-15s - %(name)s - %(levelname)s - {"callingfunc": \
-    "%(callingfunc)s", "module": "%(module)s", "function": "%(funcName)s", \
-        %(message)s}'
-basicConfig(format=FORMAT)
-logger.setLevel(INFO)
-# Add extra kwargs to message format
-logger.addHandler(NullHandler())
-logger = cast(Logger, LoggerAdapter(logger, EXTRA))
+logger = get_logger(__name__, INFO)
 
 
 if TYPE_CHECKING:

--- a/src/dsdk/mongo.py
+++ b/src/dsdk/mongo.py
@@ -102,9 +102,9 @@ class EvidenceMixin(Mixin):
             with self.open_mongo() as database:
                 key = insert_one(database.batches, doc)
                 logger.info(
-                    '"action": "insert", "database": "%s", "collection": "%s"',
-                    database.name,
-                    database.collection.name,
+                    f'"action": "insert", '
+                    f'"database": "{database.name}", '
+                    f'"collection": "{database.collection.name}"'
                 )
             yield batch
 
@@ -112,9 +112,9 @@ class EvidenceMixin(Mixin):
         with self.open_mongo() as database:
             update_one(database.batches, key, doc)
             logger.info(
-                '"action": "update", "database": "%s", "collection": "%s"',
-                database.name,
-                database.collection.name,
+                f'"action": "update", '
+                f'"database": "{database.name}", '
+                f'"collection": "{database.collection.name}"'
             )
 
     def store_evidence(self, batch: Batch, *args, **kwargs) -> None:
@@ -140,11 +140,10 @@ class EvidenceMixin(Mixin):
                 # TODO: Better exception
             df.drop(columns=["batch_id"], inplace=True)
             logger.info(
-                '"action": "insert_many", "database": "%s", \
-                    "collection": "%s", "count": %s',
-                database.name,
-                database.collection.name,
-                len(df.index),
+                f'"action": "insert_many", '
+                f'"database": "{database.name}", '
+                f'"collection": "{database.collection.name}", '
+                f'"count": {len(df.index)}'
             )
 
 

--- a/src/dsdk/mssql.py
+++ b/src/dsdk/mssql.py
@@ -5,37 +5,21 @@ from __future__ import annotations
 
 from abc import ABC
 from contextlib import contextmanager
-from logging import (
-    INFO,
-    Logger,
-    LoggerAdapter,
-    NullHandler,
-    basicConfig,
-    getLogger,
-)
+from logging import INFO
 from typing import TYPE_CHECKING, Generator, Optional, cast
 
 from configargparse import ArgParser as ArgumentParser
 
 from .service import Service
+from .utils import get_logger
+
+logger = get_logger(__file__, INFO)
 
 try:
     # Since not everyone will use mssql
     from sqlalchemy import create_engine
 except ImportError:
     create_engine = None
-
-# TODO Add import calling function from parent application
-EXTRA = {"callingfunc": ""}
-logger = getLogger(__name__)
-FORMAT = '%(asctime)-15s - %(name)s - %(levelname)s - {"callingfunc": \
-    "%(callingfunc)s", "module": "%(module)s", "function": "%(funcName)s", \
-        %(message)s}'
-basicConfig(format=FORMAT)
-logger.setLevel(INFO)
-# Add extra kwargs to message format
-logger.addHandler(NullHandler())
-logger = cast(Logger, LoggerAdapter(logger, EXTRA))
 
 
 if TYPE_CHECKING:

--- a/src/dsdk/mssql.py
+++ b/src/dsdk/mssql.py
@@ -13,7 +13,7 @@ from configargparse import ArgParser as ArgumentParser
 from .service import Service
 from .utils import get_logger
 
-logger = get_logger(__file__, INFO)
+logger = get_logger(__name__, INFO)
 
 try:
     # Since not everyone will use mssql

--- a/src/dsdk/service.py
+++ b/src/dsdk/service.py
@@ -15,7 +15,7 @@ from configargparse import Namespace
 
 from .utils import get_logger
 
-logger = get_logger(__file__, INFO)
+logger = get_logger(__name__, INFO)
 
 
 class Interval:  # pylint: disable=too-few-public-methods
@@ -161,7 +161,7 @@ class Service:
         record = Interval(on=datetime.now(timezone.utc), end=None)
         yield Batch(key, record)
         record.end = datetime.now(timezone.utc)
-        logger.info('"key": "%s"', key)
+        logger.info(f'"action": "open_batch", ' f'"key": "{key}"')
 
     def store_evidence(  # pylint: disable=no-self-use,unused-argument
         self, batch: Batch, *args, **kwargs
@@ -170,7 +170,11 @@ class Service:
         while args:
             key, df, *args = args  # type: ignore
             batch.evidence[key] = df
-        logger.info('"key": "%s", "count": %s', key, len(batch.evidence))
+        logger.info(
+            f'"action": "store_evidence", '
+            f'"key": "{key}", '
+            f'"count": "{len(batch.evidence)}"'
+        )
 
 
 class Task:  # pylint: disable=too-few-public-methods

--- a/src/dsdk/service.py
+++ b/src/dsdk/service.py
@@ -6,31 +6,16 @@ from __future__ import annotations
 from collections import OrderedDict
 from contextlib import contextmanager
 from datetime import datetime, timezone
-from logging import (
-    INFO,
-    Logger,
-    LoggerAdapter,
-    NullHandler,
-    basicConfig,
-    getLogger,
-)
+from logging import INFO
 from sys import argv as sys_argv
 from typing import Any, Dict, Generator, Optional, Sequence, Tuple, cast
 
 from configargparse import ArgParser as ArgumentParser
 from configargparse import Namespace
 
-# TODO Add import calling function from parent application
-EXTRA = {"callingfunc": ""}
-logger = getLogger(__name__)
-FORMAT = '%(asctime)-15s - %(name)s - %(levelname)s - {"callingfunc": \
-    "%(callingfunc)s", "module": "%(module)s", "function": "%(funcName)s", \
-        %(message)s}'
-basicConfig(format=FORMAT)
-logger.setLevel(INFO)
-# Add extra kwargs to message format
-logger.addHandler(NullHandler())
-logger = cast(Logger, LoggerAdapter(logger, EXTRA))
+from .utils import get_logger
+
+logger = get_logger(__file__, INFO)
 
 
 class Interval:  # pylint: disable=too-few-public-methods

--- a/src/dsdk/service.py
+++ b/src/dsdk/service.py
@@ -173,7 +173,7 @@ class Service:
         logger.info(
             f'"action": "store_evidence", '
             f'"key": "{key}", '
-            f'"count": "{len(batch.evidence)}"'
+            f'"count": {len(batch.evidence)}'
         )
 
 

--- a/src/dsdk/utils.py
+++ b/src/dsdk/utils.py
@@ -6,17 +6,53 @@ from __future__ import annotations
 from functools import wraps
 from json import dump as json_dump
 from json import load as json_load
-from logging import NullHandler, getLogger
+from logging import INFO, Formatter, LoggerAdapter, StreamHandler, getLogger
 from pickle import dump as pickle_dump
 from pickle import load as pickle_load
+from sys import stdout
 from time import sleep as default_sleep
 from typing import Any, Callable, Dict, List, Optional, Sequence
 
 from pandas import DataFrame
 from pandas import concat as pd_concat
 
-logger = getLogger(__name__)
-logger.addHandler(NullHandler())
+
+def get_logger(name, level=INFO):
+    """Get logger.
+
+    Actual handlers are typically set by the application.
+    Libraries (like DSDK) typically use a NullHandler, so that the application
+        logger configuration is used.
+
+    Use this function to hide the logger implementation/config for now.
+    Show that the conventions demonstrated here work for the applications.
+    """
+    # TODO Pass calling function from parent application
+    defaults = {"callingfunc": ""}
+    formatter_string = " - ".join(
+        (
+            "%(asctime)-15s",
+            "%(name)s",
+            "%(levelname)s",
+            ", ".join(
+                (
+                    '{"callingfunc": "%(callingfunc)s"',
+                    '"module": "%(module)s"',
+                    '"function": "%(funcName)s"',
+                    "%(message)s}",
+                )
+            ),
+        )
+    )
+    handler = StreamHandler(stdout)
+    handler.setLevel(level)
+    handler.setFormatter(Formatter(formatter_string))
+    result = getLogger(name)
+    result.addHandler(handler)
+    return LoggerAdapter(result, defaults)
+
+
+logger = get_logger(__file__)
 
 
 def chunks(sequence: Sequence[Any], n: int):

--- a/src/dsdk/utils.py
+++ b/src/dsdk/utils.py
@@ -48,11 +48,12 @@ def get_logger(name, level=INFO):
     handler.setLevel(level)
     handler.setFormatter(Formatter(formatter_string))
     result = getLogger(name)
+    result.propagate = False
     result.addHandler(handler)
     return LoggerAdapter(result, defaults)
 
 
-logger = get_logger(__file__)
+logger = get_logger(__name__)
 
 
 def chunks(sequence: Sequence[Any], n: int):


### PR DESCRIPTION
Extract logger config.

When becker and I looked into logging for libraries, the conclusion was that libraries use a NullHandler() and rely on the application to configure the loggers so that log messages came from the app, not the library. Perhaps this will solve the issue you indicated where the calling func and module are wanted, but unavailable. I'm less certain about the calling function, even though that would be useful: https://stackoverflow.com/questions/2654113/how-to-get-the-callers-method-name-in-the-called-method

Essentially, the NullHandler() ensures that the logging function calls are recognized and complete, but nothing is logged out unless the application does some configuration.

This patch extracts your logging configuration as-is, with the idea that we can demonstrate your logging format conventions, eventually push those changes into the apps, and revert the library back to the NullHandler() --or not-- by changing this isolated function definition.