### PR TITLE
Add union all

### DIFF
--- a/src/dsdk/mssql.py
+++ b/src/dsdk/mssql.py
@@ -59,8 +59,9 @@ class Persistor(Messages, BasePersistor):
     @classmethod
     def union_all(cls, cur, keys: Sequence[Any],) -> str:
         """Return 'union all select %s...' clause."""
-        union = "".join("    union all select %s\n" for _ in keys)
-        union = _mssql.substitute_params(union, keys).decode("utf-8")
+        params = tuple(keys)
+        union = "".join("    union all select %s\n" for _ in params)
+        union = _mssql.substitute_params(union, params).decode("utf-8")
         # in case the mogrified strings have %
         # mistaken for python placeholders
         # when mogrified twice.

--- a/src/dsdk/mssql.py
+++ b/src/dsdk/mssql.py
@@ -68,7 +68,8 @@ class Persistor(Messages, BasePersistor):
         for table in self.tables:
             try:
                 statement = self.extant(table)
-                logger.info(self.EXTANT, statement)
+                logger.info(self.EXTANT, table)
+                logger.debug(self.EXTANT, statement)
                 cur.execute(statement)
                 for row in cur:
                     n, *_ = row

--- a/src/dsdk/mssql.py
+++ b/src/dsdk/mssql.py
@@ -60,7 +60,7 @@ class Persistor(Messages, BasePersistor):
     def union_all(cls, cur, keys: Sequence[Any],) -> str:
         """Return 'union all select %s...' clause."""
         union = "".join("    union all select %s\n" for _ in keys)
-        union = _mssql.substitute_params(union, keys)
+        union = _mssql.substitute_params(union, keys).decode("utf-8")
         # in case the mogrified strings have %
         # mistaken for python placeholders
         # when mogrified twice.

--- a/src/dsdk/mssql.py
+++ b/src/dsdk/mssql.py
@@ -59,7 +59,7 @@ class Persistor(Messages, BasePersistor):
     @classmethod
     def mogrify(cls, cur, query: str, parameters: Any,) -> bytes:
         """Safely mogrify parameters into query or fragment."""
-        return _mssql.substitute_params(query, parameters)
+        return _mssql.substitute_params(query, parameters)  # type: ignore
 
     def check(self, cur, exceptions=(DatabaseError, InterfaceError)):
         """check."""

--- a/src/dsdk/mssql.py
+++ b/src/dsdk/mssql.py
@@ -59,9 +59,9 @@ class Persistor(Messages, BasePersistor):
     @classmethod
     def union_all(cls, cur, keys: Sequence[Any],) -> str:
         """Return 'union all select %s...' clause."""
-        params = tuple(keys)
-        union = "".join("    union all select %s\n" for _ in params)
-        union = _mssql.substitute_params(union, params).decode("utf-8")
+        parameters = tuple(keys)
+        union = "".join("    union all select %s\n" for _ in parameters)
+        union = _mssql.substitute_params(union, parameters).decode("utf-8")
         # in case the mogrified strings have %
         # mistaken for python placeholders
         # when mogrified twice.

--- a/src/dsdk/mssql.py
+++ b/src/dsdk/mssql.py
@@ -7,7 +7,7 @@ from abc import ABC
 from contextlib import contextmanager
 from json import dumps
 from logging import getLogger
-from typing import TYPE_CHECKING, Any, Generator, Sequence, Type, cast
+from typing import TYPE_CHECKING, Any, Generator, Type, cast
 
 from configargparse import ArgParser as ArgumentParser
 
@@ -57,16 +57,9 @@ class Persistor(Messages, BasePersistor):
     """Persistor."""
 
     @classmethod
-    def union_all(cls, cur, keys: Sequence[Any],) -> str:
-        """Return 'union all select %s...' clause."""
-        parameters = tuple(keys)
-        union = "".join("    union all select %s\n" for _ in parameters)
-        union = _mssql.substitute_params(union, parameters).decode("utf-8")
-        # in case the mogrified strings have %
-        # mistaken for python placeholders
-        # when mogrified twice.
-        union = union.replace("%", "%%")
-        return union
+    def mogrify(cls, cur, query: str, parameters: Any,) -> bytes:
+        """Safely mogrify parameters into query or fragment."""
+        return _mssql.substitute_params(query, parameters)
 
     def check(self, cur, exceptions=(DatabaseError, InterfaceError)):
         """check."""

--- a/src/dsdk/persistor.py
+++ b/src/dsdk/persistor.py
@@ -116,6 +116,8 @@ class AbstractPersistor:
         keys = {
             key: cls.union_all(cur, sequence) for key, sequence in keys.items()
         }
+        for key, value in keys.items():
+            logger.info("%s: %s", key, value)
         query = query.format(keys)
         cur.execute(query, parameters)
         rows = cur.fetchall()

--- a/src/dsdk/persistor.py
+++ b/src/dsdk/persistor.py
@@ -113,11 +113,10 @@ class AbstractPersistor:
             keys = {}
         if parameters is None:
             parameters = {}
-        logger.info("%s", tuple(keys.keys()))
         keys = {
             key: cls.union_all(cur, sequence) for key, sequence in keys.items()
         }
-        query = query.format(keys)
+        query = query.format(**keys)
         cur.execute(query, parameters)
         rows = cur.fetchall()
         df = DataFrame(rows)

--- a/src/dsdk/persistor.py
+++ b/src/dsdk/persistor.py
@@ -136,7 +136,7 @@ class AbstractPersistor:
     def union_all(cls, cur, keys: Sequence[Any],) -> str:
         """Return 'union all select %s...' clause."""
         parameters = tuple(keys)
-        union = "".join("    union all select %s\n" for _ in parameters)
+        union = "\n    ".join("union all select %s" for _ in parameters)
         union = cls.mogrify(cur, union, parameters).decode("utf-8")
         # in case the mogrified strings have %
         # mistaken for python placeholders

--- a/src/dsdk/persistor.py
+++ b/src/dsdk/persistor.py
@@ -117,10 +117,10 @@ class AbstractPersistor:
             key: cls.union_all(cur, sequence) for key, sequence in keys.items()
         }
         query = query.format(**keys)
+        rendered = cls.mogrify(cur, query, parameters).decode("utf-8")
         with open("tmp.sql", "w") as fout:
-            fout.write(cls.mogrify(cur, query, parameters).decode("utf-8"))
-
-        cur.execute(query, parameters)
+            fout.write(rendered)
+        cur.execute(rendered)
         rows = cur.fetchall()
         df = DataFrame(rows)
         columns = (each[0] for each in cur.description)

--- a/src/dsdk/persistor.py
+++ b/src/dsdk/persistor.py
@@ -117,7 +117,7 @@ class AbstractPersistor:
             key: cls.union_all(cur, sequence) for key, sequence in keys.items()
         }
         query = query.format(**keys)
-        with open("tmp.sql") as fout:
+        with open("tmp.sql", "w") as fout:
             fout.write(cls.mogrify(cur, query, parameters).decode("utf-8"))
 
         cur.execute(query, parameters)

--- a/src/dsdk/persistor.py
+++ b/src/dsdk/persistor.py
@@ -113,11 +113,10 @@ class AbstractPersistor:
             keys = {}
         if parameters is None:
             parameters = {}
+        logger.info("%s", tuple(keys.keys()))
         keys = {
             key: cls.union_all(cur, sequence) for key, sequence in keys.items()
         }
-        for key, value in keys.items():
-            logger.info("%s: %s", key, value)
         query = query.format(keys)
         cur.execute(query, parameters)
         rows = cur.fetchall()

--- a/src/dsdk/persistor.py
+++ b/src/dsdk/persistor.py
@@ -119,7 +119,7 @@ class AbstractPersistor:
         }
         query = query.format(**keys)
         rendered = cls.mogrify(cur, query, parameters).decode("utf-8")
-        with NamedTemporaryFile("w", delete="false", suffix=".sql") as fout:
+        with NamedTemporaryFile("w", delete=False, suffix=".sql") as fout:
             fout.write(rendered)
         cur.execute(rendered)
         rows = cur.fetchall()

--- a/src/dsdk/persistor.py
+++ b/src/dsdk/persistor.py
@@ -8,6 +8,7 @@ from contextlib import contextmanager
 from json import dumps
 from logging import getLogger
 from re import compile as re_compile
+from tempfile import NamedTemporaryFile
 from typing import Any, Dict, Generator, Optional, Sequence, Tuple
 
 from pandas import DataFrame, concat
@@ -118,7 +119,7 @@ class AbstractPersistor:
         }
         query = query.format(**keys)
         rendered = cls.mogrify(cur, query, parameters).decode("utf-8")
-        with open("tmp.sql", "w") as fout:
+        with NamedTemporaryFile("w", delete="false", suffix=".sql") as fout:
             fout.write(rendered)
         cur.execute(rendered)
         rows = cur.fetchall()

--- a/src/dsdk/persistor.py
+++ b/src/dsdk/persistor.py
@@ -139,10 +139,6 @@ class AbstractPersistor:
         parameters = tuple(keys)
         union = "\n    ".join("union all select %s" for _ in parameters)
         union = cls.mogrify(cur, union, parameters).decode("utf-8")
-        # in case the mogrified strings have %
-        # mistaken for python placeholders
-        # when mogrified twice.
-        union = union.replace("%", "%%")
         return union
 
     def __init__(self, sql: Namespace, tables: Tuple[str, ...]):

--- a/src/dsdk/persistor.py
+++ b/src/dsdk/persistor.py
@@ -108,7 +108,17 @@ class AbstractPersistor:
     ) -> DataFrame:
         """Return df from query by key sequences and parameters.
 
-        Query is expected to use {name} for keys and %(name)s for parameters.
+        Query is expected to use {name} for key sequences and %(name)s
+        for parameters.
+        The mogrified fragments produced by union_all are mogrified again.
+        There is a chance that python placeholders could be injected py the
+        first pass from sequence data.
+        However, it seems that percent in `'...%s...'` or `'...'%(name)s...'`
+        inside string literals produced from the first mogrification pass are
+        not interpreted as parameter placeholders in the second pass by
+        the pymssql driver.
+        Actual placeholders to by interpolacted by the driver are not
+        inside quotes.
         """
         if keys is None:
             keys = {}

--- a/src/dsdk/persistor.py
+++ b/src/dsdk/persistor.py
@@ -114,7 +114,7 @@ class AbstractPersistor:
         if parameters is None:
             parameters = {}
         keys = {
-            key: cls.union_all(cur, values) for key, values in keys.items()
+            key: cls.union_all(cur, sequence) for key, sequence in keys.items()
         }
         query = query.format(keys)
         cur.execute(query, parameters)

--- a/src/dsdk/persistor.py
+++ b/src/dsdk/persistor.py
@@ -117,7 +117,9 @@ class AbstractPersistor:
             key: cls.union_all(cur, sequence) for key, sequence in keys.items()
         }
         query = query.format(**keys)
-        logger.info(query)
+        with open("tmp.sql") as fout:
+            fout.write(cls.mogrify(cur, query, parameters).decode("utf-8"))
+
         cur.execute(query, parameters)
         rows = cur.fetchall()
         df = DataFrame(rows)

--- a/src/dsdk/postgres.py
+++ b/src/dsdk/postgres.py
@@ -7,7 +7,7 @@ from abc import ABC
 from contextlib import contextmanager
 from json import dumps
 from logging import getLogger
-from typing import TYPE_CHECKING, Any, Dict, Generator, Sequence, Type, cast
+from typing import TYPE_CHECKING, Any, Dict, Generator, Type, cast
 
 from configargparse import ArgParser as ArgumentParser
 from numpy import integer
@@ -118,16 +118,9 @@ class Persistor(Messages, BasePersistor):
     """Persistor."""
 
     @classmethod
-    def union_all(cls, cur, keys: Sequence[Any],) -> str:
-        """Return 'union all select %s...' clause."""
-        parameters = tuple(keys)
-        union = "".join("    union all select %s\n" for _ in parameters)
-        union = cur.mogrify(union, parameters).decode("utf-8")
-        # in case the mogrified strings have %
-        # mistaken for python placeholders
-        # when mogrified twice.
-        union = union.replace("%", "%%")
-        return union
+    def mogrify(cls, cur, query: str, parameters: Any,) -> bytes:
+        """Safely mogrify parameters into query or fragment."""
+        return cur.mogrify(query, parameters)
 
     def check(self, cur, exceptions=(DatabaseError, InterfaceError)):
         """Check."""

--- a/src/dsdk/postgres.py
+++ b/src/dsdk/postgres.py
@@ -121,7 +121,7 @@ class Persistor(Messages, BasePersistor):
     def union_all(cls, cur, keys: Sequence[Any],) -> str:
         """Return 'union all select %s...' clause."""
         union = "".join("    union all select %s\n" for _ in keys)
-        union = cur.mogrify(union, keys)
+        union = cur.mogrify(union, keys).decode("utf-8")
         # in case the mogrified strings have %
         # mistaken for python placeholders
         # when mogrified twice.

--- a/src/dsdk/postgres.py
+++ b/src/dsdk/postgres.py
@@ -120,9 +120,9 @@ class Persistor(Messages, BasePersistor):
     @classmethod
     def union_all(cls, cur, keys: Sequence[Any],) -> str:
         """Return 'union all select %s...' clause."""
-        params = tuple(keys)
-        union = "".join("    union all select %s\n" for _ in params)
-        union = cur.mogrify(union, params).decode("utf-8")
+        parameters = tuple(keys)
+        union = "".join("    union all select %s\n" for _ in parameters)
+        union = cur.mogrify(union, parameters).decode("utf-8")
         # in case the mogrified strings have %
         # mistaken for python placeholders
         # when mogrified twice.

--- a/src/dsdk/postgres.py
+++ b/src/dsdk/postgres.py
@@ -7,7 +7,7 @@ from abc import ABC
 from contextlib import contextmanager
 from json import dumps
 from logging import getLogger
-from typing import TYPE_CHECKING, Any, Dict, Generator, Type, cast
+from typing import TYPE_CHECKING, Any, Dict, Generator, Sequence, Type, cast
 
 from configargparse import ArgParser as ArgumentParser
 from numpy import integer
@@ -116,6 +116,17 @@ class Messages:  # pylint: disable=too-few-public-methods
 
 class Persistor(Messages, BasePersistor):
     """Persistor."""
+
+    @classmethod
+    def union_all(cls, cur, keys: Sequence[Any],) -> str:
+        """Return 'union all select %s...' clause."""
+        union = "".join("    union all select %s\n" for _ in keys)
+        union = cur.mogrify(union, keys)
+        # in case the mogrified strings have %
+        # mistaken for python placeholders
+        # when mogrified twice.
+        union = union.replace("%", "%%")
+        return union
 
     def check(self, cur, exceptions=(DatabaseError, InterfaceError)):
         """Check."""

--- a/src/dsdk/postgres.py
+++ b/src/dsdk/postgres.py
@@ -120,8 +120,9 @@ class Persistor(Messages, BasePersistor):
     @classmethod
     def union_all(cls, cur, keys: Sequence[Any],) -> str:
         """Return 'union all select %s...' clause."""
-        union = "".join("    union all select %s\n" for _ in keys)
-        union = cur.mogrify(union, keys).decode("utf-8")
+        params = tuple(keys)
+        union = "".join("    union all select %s\n" for _ in params)
+        union = cur.mogrify(union, params).decode("utf-8")
         # in case the mogrified strings have %
         # mistaken for python placeholders
         # when mogrified twice.


### PR DESCRIPTION
Replace sql `in` clause with repeated `union all select` for all items in a sequence.

Generalize the replacement of multiple `in` sequences while still allowing for scalar parameters.

In many cases a join against a named common table expression with `union all select` is simpler to understand than an long embedded `in` clause mixed in with other join conditions. The `union all select` also allows developers to specify the data type of the sequence items to explicitly match the database schema so that indexes will be used by the query planner.

For pulling labs in conversation connect:

The original `in` code chunked 500 patients at a time and took anywhere between 16 and 160 minutes to run. An `in` clause with all >5000 patients does not return.

The replaced `union all select` code pulled the labs for all >5000 patients and takes <2 - 6 minutes. Both the patient ids and the labs sequences are replaced.

This patch sends rendered sql to a temporary file for debugging purposes.