### PR TITLE
Replace pkg_resources with importlib

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: build
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        target: ["3.9", "3.10"]
+        target: ["3.9", "3.10", "3.11", "3.12"]
     steps:
       - name: checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
         target: ["3.9", "3.10"]
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: build
         run: |

--- a/src/dsdk/service.py
+++ b/src/dsdk/service.py
@@ -7,6 +7,7 @@ from collections import OrderedDict
 from collections.abc import Generator, Mapping, Sequence
 from contextlib import contextmanager
 from datetime import date, datetime, tzinfo
+from importlib.metadata import distribution, PackageNotFoundError
 from json import dumps
 from logging import getLogger
 from typing import Any, Callable
@@ -14,15 +15,14 @@ from typing import Any, Callable
 from cfgenvy import Parser, YamlMapping
 from numpy import allclose
 from pandas import DataFrame
-from pkg_resources import DistributionNotFound, get_distribution
 
 from .interval import Interval
 from .utils import configure_logger, get_tzinfo, now_utc_datetime
 
 try:
-    __version__ = get_distribution("dsdk").version
-except DistributionNotFound:  # pragma: nocover
-    # package is not installed
+    __version__ = distribution("dsdk").version
+except PackageNotFoundError:  # pragma: nocover
+    # package not found
     pass
 
 logger = getLogger(__name__)


### PR DESCRIPTION
Deprecation warning in projects using dsdk indicate that use of pkg_resources needs replaced with importlib.metadata. Importlib is also faster.